### PR TITLE
Update lkcrypto for kernels from 5.11

### DIFF
--- a/lkcrypto.c
+++ b/lkcrypto.c
@@ -17,7 +17,11 @@
 #include <linux/kthread.h>
 #include <crypto/hash.h>
 #include <crypto/aes.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#include <crypto/sha2.h>
+#else
 #include <crypto/sha.h>
+#endif
 #include <crypto/aead.h>
 
 #define MAX_NAME_LEN  63


### PR DESCRIPTION
sha.h is now split between sha1.h and sha2.h
sha1.h is considered deprecated and will be phased out.