### PR TITLE
Use EXPORT_SYMBOL_GPL for luaopen_kcrypto

### DIFF
--- a/lkcrypto.c
+++ b/lkcrypto.c
@@ -787,4 +787,4 @@ static void __exit modexit(void)
 module_init(modinit);
 module_exit(modexit);
 MODULE_LICENSE("Dual MIT/GPL");
-EXPORT_SYMBOL(luaopen_kcrypto);
+EXPORT_SYMBOL_GPL(luaopen_kcrypto);


### PR DESCRIPTION
In kernel commit 9011e49d54dcc7653ebb8a1e05b5badb5ecfa9f9, released in 6.6 but also backported to 4.14.326, 4.19.295, 5.4.257, 5.10.195, 5.15.131, 6.1.52, 6.4.15, and 6.5.2, it became illegal to use symbol_get to load other modules' symbols that aren't exported as GPL-only.

symbol_get is exactly the API used by Lunatik to load the luaopen_* functions. So we need to make sure we use EXPORT_SYMBOL_GPL here, otherwise the aforementioned (or later) kernel versions will not be able to load us at all. Fortunately both ends are already GPL-licensed so no other changes are needed.